### PR TITLE
Add GNU ELPA badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ioccur
 ======
 
+[![GNU ELPA](https://elpa.gnu.org/packages/ioccur.svg)](https://elpa.gnu.org/packages/ioccur.html)
+
 incremental occur for Emacs
 
 Probably you will want to use and enhanced version supporting multiples buffers and more


### PR DESCRIPTION
This adds a nice GNU ELPA badge to README.md. Thanks!

PS. The badge is currently not working for this package, see https://debbugs.gnu.org/cgi/bugreport.cgi?bug=52843, but it will look great once that bug is fixed.  ;-)